### PR TITLE
Set permission 644 to all new uploaded files

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -151,9 +151,10 @@ CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# Maximum file upload size for forms
+# Maximum file upload size and permissions
 
 MAX_UPLOAD_SIZE = 26214400  # 25 MB
+FILE_UPLOAD_PERMISSIONS = 0o644
 
 # Phone number format
 


### PR DESCRIPTION
New files uploaded don't give read permissions for other users in the same grop nor other users. Therefore, nginx can't serve them because it just can't read them. Setting it to 644 should make Django use `-rw-r--r--` instead of the current `-rw-------`.